### PR TITLE
feat: add enterprise switcher

### DIFF
--- a/src/components/EnterpriseSwitcher.tsx
+++ b/src/components/EnterpriseSwitcher.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Building2 } from 'lucide-react';
+
+interface Enterprise {
+  key: string;
+  name: string;
+}
+
+interface EnterpriseSwitcherProps {
+  enterprises: Enterprise[];
+  selectedKey?: string;
+  onEnterpriseChange: (key: string) => void;
+  isLoading?: boolean;
+}
+
+export function EnterpriseSwitcher({
+  enterprises,
+  selectedKey,
+  onEnterpriseChange,
+  isLoading = false
+}: EnterpriseSwitcherProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || isLoading) {
+    return (
+      <div className="flex items-center space-x-2">
+        <Building2 className="w-4 h-4 text-muted-foreground" />
+        <div className="w-48 h-10 bg-muted animate-pulse rounded-md" />
+      </div>
+    );
+  }
+
+  if (enterprises.length === 0) {
+    return (
+      <div className="flex items-center space-x-2">
+        <Building2 className="w-4 h-4 text-muted-foreground" />
+        <Badge variant="outline" className="text-muted-foreground">
+          Aucune entreprise
+        </Badge>
+      </div>
+    );
+  }
+
+  const selected = enterprises.find(e => e.key === selectedKey);
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Building2 className="w-4 h-4 text-muted-foreground" />
+      <Select value={selectedKey} onValueChange={onEnterpriseChange}>
+        <SelectTrigger className="w-48">
+          <SelectValue placeholder="Sélectionner une entreprise">
+            {selected && <span className="truncate">{selected.name}</span>}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {enterprises.map((ent) => (
+            <SelectItem key={ent.key} value={ent.key}>
+              {ent.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {enterprises.length > 0 && (
+        <Badge variant="secondary" className="text-xs">
+          {enterprises.length} entreprise{enterprises.length > 1 ? 's' : ''}
+        </Badge>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/ImpotForm.tsx
+++ b/src/components/ImpotForm.tsx
@@ -8,9 +8,10 @@ import { supabase } from '@/integrations/supabase/client';
 interface ImpotFormProps {
   guildId: string;
   entreprise?: string;
+  entrepriseName?: string;
 }
 
-export function ImpotForm({ guildId, entreprise }: ImpotFormProps) {
+export function ImpotForm({ guildId, entreprise, entrepriseName }: ImpotFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -218,7 +219,7 @@ export function ImpotForm({ guildId, entreprise }: ImpotFormProps) {
         <CardHeader>
           <CardTitle className="text-lg flex items-center space-x-2">
             <Receipt className="w-5 h-5 text-primary" />
-            <span>Résumé Fiscal</span>
+            <span>Résumé Fiscal{entrepriseName ? ` - ${entrepriseName}` : ''}</span>
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -293,3 +294,4 @@ export function ImpotForm({ guildId, entreprise }: ImpotFormProps) {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- allow manual enterprise selection with EnterpriseSwitcher
- show selected enterprise in fiscal summary

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, forbidden require)


------
https://chatgpt.com/codex/tasks/task_e_689bb23a0168832cbcfd62a6d5a3181f