### PR TITLE
Allow DOT role to access staff-only features

### DIFF
--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -105,7 +105,7 @@ export function isDot(role: Role): boolean {
 }
 
 export function canAccessDotation(role: Role): boolean {
-  return isStaff(role) || isPatron(role);
+  return isStaff(role) || isPatron(role) || isDot(role);
 }
 
 export function canAccessImpot(role: Role): boolean {
@@ -113,15 +113,15 @@ export function canAccessImpot(role: Role): boolean {
 }
 
 export function canAccessBlanchiment(role: Role): boolean {
-  return isStaff(role) || isPatron(role);
+  return isStaff(role) || isPatron(role) || isDot(role);
 }
 
 export function canAccessStaffConfig(role: Role): boolean {
-  return isStaff(role);
+  return isStaff(role) || isDot(role);
 }
 
 export function canAccessCompanyConfig(role: Role): boolean {
-  return isStaff(role) || isPatron(role) || isCoPatron(role);
+  return isStaff(role) || isPatron(role) || isCoPatron(role) || isDot(role);
 }
 
 // Fonction pour obtenir le nom d'affichage du rôle

--- a/src/pages/CompanyConfig.tsx
+++ b/src/pages/CompanyConfig.tsx
@@ -267,7 +267,7 @@ useEffect(() => {
           <CardContent className="p-8 text-center">
             <Shield className="w-10 h-10 mx-auto mb-3 text-destructive" />
             <p className="font-semibold mb-1">Accès restreint</p>
-            <p className="text-sm text-muted-foreground">Cette page est réservée aux patrons, co-patrons et staff.</p>
+          <p className="text-sm text-muted-foreground">Cette page est réservée aux patrons, co-patrons, DOT et staff.</p>
             <Button className="mt-4" onClick={() => navigate(`/?guild=${guildId}`)}>
               <ArrowLeft className="w-4 h-4 mr-2"/>Retour
             </Button>


### PR DESCRIPTION
## Summary
- extend dot role permissions for dotation, blanchiment, and configuration areas
- clarify CompanyConfig access message to include DOT

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-require-imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bb23af180832c8bff9204fda684a9